### PR TITLE
Improve Kaizen Sushi website with images and layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<html lang="es">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Kaizen Sushi</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;700&display=swap" rel="stylesheet" />
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <header class="navbar">
+      <div class="logo">Kaizen Sushi</div>
+      <nav>
+        <a href="#about">Nosotros</a>
+        <a href="#menu">Menú</a>
+        <a href="#contacto">Contacto</a>
+      </nav>
+    </header>
+
+    <section class="hero">
+      <h1>Bienvenido a Kaizen Sushi</h1>
+      <p>Sushi bar contemporáneo inspirado en la filosofía japonesa de mejora continua.</p>
+    </section>
+
+    <section id="about" class="content">
+      <h2>Filosofía Kaizen</h2>
+      <p>
+        En Kaizen Sushi creemos en la mejora continua. Seleccionamos ingredientes
+        frescos y perfeccionamos cada plato para ofrecer una experiencia
+        memorable en cada visita.
+      </p>
+    </section>
+
+    <section id="menu" class="content">
+      <h2>Menú</h2>
+      <div class="menu-grid">
+        <div class="menu-item">
+          <img src="https://images.unsplash.com/photo-1562967916-eb82221dfb36?auto=format&fit=crop&w=400&q=80" alt="Nigiri de salmón" />
+          <h3>Nigiri clásico</h3>
+        </div>
+        <div class="menu-item">
+          <img src="https://images.unsplash.com/photo-1607315908954-d99856d19e71?auto=format&fit=crop&w=400&q=80" alt="Roll especial" />
+          <h3>Roll especial</h3>
+        </div>
+        <div class="menu-item">
+          <img src="https://images.unsplash.com/photo-1553621042-f6e147245754?auto=format&fit=crop&w=400&q=80" alt="Sashimi fresco" />
+          <h3>Sashimi de temporada</h3>
+        </div>
+        <div class="menu-item">
+          <img src="https://images.unsplash.com/photo-1598514982738-0735c0ae34bf?auto=format&fit=crop&w=400&q=80" alt="Edamames" />
+          <h3>Edamames</h3>
+        </div>
+      </div>
+    </section>
+
+    <section id="contacto" class="content">
+      <h2>Contacto</h2>
+      <p>Calle Ficticia 123, Ciudad Gótica</p>
+      <p>Teléfono: <a href="tel:+34123456789">+34 123 456 789</a></p>
+      <p>Horarios: Lunes a Domingo 12:00 - 23:00</p>
+    </section>
+
+    <footer>
+      <p>&copy; 2023 Kaizen Sushi</p>
+    </footer>
+  </body>
+</html>

--- a/style.css
+++ b/style.css
@@ -1,0 +1,84 @@
+body {
+  font-family: 'Roboto', sans-serif;
+  margin: 0;
+  background-color: #fff;
+  color: #333;
+}
+
+.navbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1rem 2rem;
+  background-color: rgba(0, 0, 0, 0.8);
+  position: fixed;
+  width: 100%;
+  top: 0;
+  z-index: 1000;
+  color: #fff;
+}
+
+.navbar .logo {
+  font-weight: 700;
+  font-size: 1.2rem;
+}
+
+.navbar nav a {
+  color: #fff;
+  margin-left: 1rem;
+  text-decoration: none;
+  font-weight: 500;
+}
+
+.hero {
+  height: 80vh;
+  background: url('https://images.unsplash.com/photo-1543226862-8609dc236a10?auto=format&fit=crop&w=1200&q=80') center/cover no-repeat;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  text-align: center;
+  color: #fff;
+  padding: 0 1rem;
+}
+
+.hero h1 {
+  font-size: 3rem;
+  margin: 0.5rem 0;
+}
+
+.hero p {
+  font-size: 1.2rem;
+  max-width: 600px;
+}
+
+.content {
+  padding: 4rem 1rem;
+  max-width: 1200px;
+  margin: 0 auto;
+}
+
+.menu-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 2rem;
+  margin-top: 2rem;
+}
+
+.menu-item img {
+  width: 100%;
+  border-radius: 8px;
+  display: block;
+}
+
+.menu-item h3 {
+  text-align: center;
+  margin-top: 0.5rem;
+}
+
+footer {
+  text-align: center;
+  background-color: #222;
+  color: #fff;
+  padding: 2rem 1rem;
+}


### PR DESCRIPTION
## Summary
- Overhauled `index.html` with navigation bar, hero header, menu gallery with images, and contact section for Kaizen Sushi.
- Updated `style.css` to use Google Fonts, responsive hero background, and a grid layout for menu items.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68932012b058832b86c382d3aa3cf5c2